### PR TITLE
Support of allow_named_servers setting

### DIFF
--- a/yarnspawner/apihandler.py
+++ b/yarnspawner/apihandler.py
@@ -1,4 +1,3 @@
-import json
 from tornado import web
 from jupyterhub.apihandlers import APIHandler, default_handlers
 
@@ -12,9 +11,24 @@ class YarnSpawnerAPIHandler(APIHandler):
         user = self.current_user
         data = self.get_json_body()
         port = int(data.get('port', 0))
-        user.spawner.current_port = port
-        self.finish(json.dumps({"message": "YarnSpawner port configured"}))
-        self.set_status(201)
+        name = data.get('name', '')
+
+        self.log.debug("Registering port number %i for spawner '%s' of user '%s'", port, name, user.name)
+
+        resp_code = 201
+        resp_body = {"message": "YarnSpawner port configured"}
+        if name:
+            # if allow_named_servers
+            if name in user.spawners:
+                user.spawners[name].current_port = port
+            else:
+                resp_code = 400
+                resp_body = {"message": "YarnSpawner not found for named server {}".format(name)}
+        else:
+            user.spawner.current_port = port
+
+        self.finish(resp_body)
+        self.set_status(resp_code)
 
 
 default_handlers.append((r"/api/yarnspawner", YarnSpawnerAPIHandler))

--- a/yarnspawner/singleuser.py
+++ b/yarnspawner/singleuser.py
@@ -15,7 +15,8 @@ class YarnSingleUserNotebookApp(SingleUserNotebookApp):
     def start(self):
         self.hub_auth._api_request(method='POST',
                                    url=url_path_join(self.hub_api_url, 'yarnspawner'),
-                                   json={'port': self.port})
+                                   json={'port': self.port, 'name': self.server_name})
+        self.log.debug("Starting notebook server '%s' at port %i", self.server_name, self.port)
         super().start()
 
 


### PR DESCRIPTION
This PR adds support of `allow_named_servers` setting.

Previously, only default servers were supported for the users.
Trying to start a named server for a given user led to the following behaviour: 
- remove notebook for a named server passes a port it is running on to the jupyterhub
- jupyterhub assignes the port to the default notebook of a user and not to the named one
- so after a timeout jupyterhub still considers that there are issues with starting a remote notebook and returns error even if this remote notebook was started successfully